### PR TITLE
supports the NameID as ID when userIdAttribute is set to the string 'nameid'

### DIFF
--- a/src/letswifi/browserauth/simplesamlauth.php
+++ b/src/letswifi/browserauth/simplesamlauth.php
@@ -80,7 +80,12 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 
 		static::checkIdP( $this->samlIdp, $this->as->getAuthData( 'saml:sp:IdP' ) );
 
-		return $this->getSingleAttributeValue( $this->userIdAttribute );
+		if ( $this->userIdAttribute == "nameid" ) {
+			// in SimpleSAMLphp version 2 ->value should be replaced with ->getValue()
+			return $this->as->getAuthData('saml:sp:NameID')->value;
+		} else {
+			return $this->getSingleAttributeValue( $this->userIdAttribute );
+		}
 	}
 
 	/**


### PR DESCRIPTION
A suggestion to support the use of the (Persistent) NameID instead of a SAML attribute like eduPersonPrincipalName for the user ID, by configuring ```'userIdAttribute' => 'nameid'``` (which is not a valid/standard SAML attribute AFAIK)