### PR TITLE
Use a short random ID instead of UUID for the CN

### DIFF
--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -198,7 +198,7 @@ class Realm
 		$keys = array_merge(range(0, 9), range('a', 'z'));
 		$randid = "";
 		for($i=0; $i < 16; $i++) {
-			$randid .= $keys[mt_rand(0, count($keys) - 1)];
+			$randid .= $keys[random_int(0, count($keys) - 1)];
 		}
 		return $randid;
 	}

--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -179,7 +179,7 @@ class Realm
 	protected function generateClientCertificate( User $user, DateTimeInterface $expiry ): PKCS12
 	{
 		$userKey = new PrivateKey( new OpenSSLConfig( OpenSSLConfig::KEY_EC ) );
-		$commonName = static::createUUID() . '@' . \rawurlencode( $this->getName() );
+		$commonName = static::createRANDID() . '@' . \rawurlencode( $this->getName() );
 		$dn = new DN( ['CN' => $commonName] );
 		$csr = CSR::generate( $dn, $userKey );
 		$caCert = $this->getSigningCACertificate();
@@ -191,6 +191,16 @@ class Realm
 		$this->logCompletedUserCredential( $user, $userCert );
 
 		return new PKCS12( $userCert, $userKey, [$caCert] );
+	}
+
+	private static function createRANDID(): string
+	{
+		$keys = array_merge(range(0, 9), range('a', 'z'));
+		$randid = "";
+		for($i=0; $i < 16; $i++) {
+			$randid .= $keys[mt_rand(0, count($keys) - 1)];
+		}
+		return $randid;
 	}
 
 	private static function createUUID(): string


### PR DESCRIPTION
Something like this (length 16, much shorter) or include the length of \rawurlencode( $this->getName() ); and fill up to 64 bytes.