### PR TITLE
Add additional authorization on SAML attributes via authzAttributeValue

### DIFF
--- a/etc/letswifi.conf.simplesaml.php
+++ b/etc/letswifi.conf.simplesaml.php
@@ -14,6 +14,10 @@
 			'demo.eduroam.nl' => [
 					'userIdAttribute' => 'eduPersonPrincipalName', // null for NameID
 					'samlIdp' => 'https://engine.test.surfconext.nl/authentication/idp/metadata',
+					//'authzAttributeValue' => [
+					//	'eduPersonAffiliation' => ['employee','staff'],
+					//	'eduPersonEntitlement' => 'geteduroam-user',
+					//	],
 					'idpList' => [
 							'https://example.com'
 						],

--- a/src/letswifi/browserauth/simplesamlauth.php
+++ b/src/letswifi/browserauth/simplesamlauth.php
@@ -94,15 +94,15 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 			static::checkIdPList( $this->idpList, $this->as->getAuthData('saml:AuthenticatingAuthority') );
 		}
 
-		if ( null === $this->userIdAttribute ) {
-			// in SimpleSAMLphp version 2 ->value should be replaced with ->getValue()
-			return $this->as->getAuthData( 'saml:sp:NameID' )->value;
-		}
-
 		// authzAttributeValue validates SAML attributes against the attribute-value map for additional authorization
 		if ( \count( $this->authzAttributeValue) > 0 ) {
 			// can wrap this around try {} / catch {} if we need nicer error handling
 			static::checkAuthzAttributeValue( $this->authzAttributeValue );
+		}
+
+		if ( null === $this->userIdAttribute ) {
+			// in SimpleSAMLphp version 2 ->value should be replaced with ->getValue()
+			return $this->as->getAuthData( 'saml:sp:NameID' )->value;
 		}
 
 		return $this->getSingleAttributeValue( $this->userIdAttribute );


### PR DESCRIPTION
Allows authorization based on SAML attributes via an authzAttributeValue setting, such as:
```
'authzAttributeValue' => [
        'eduPersonAffiliation' => ['employee','staff'],
        'eduPersonEntitlement' => 'geteduroam-user',
        'eduPersonPrincipalName' => ['paul@here', 'jorn@here'],
        'nlEduPersonHomeOrganizationId' => '1234',
]
```
where in multi-value values, either of the values is accepted.
