### PR TITLE
Remove old clients

### DIFF
--- a/etc/clients.php
+++ b/etc/clients.php
@@ -16,28 +16,9 @@
 		'scopes' => ['eap-metadata'],
 		'refresh' => true
 	],
-	[
-		# deprecated Windows client
-		# Also clientId stolen by ionic-app?!??!!?!
-		# https://github.com/geteduroam/ionic-app
-		'clientId' => 'f817fbcc-e8f4-459e-af75-0822d86ff47a',
-		'redirectUris' => [
-			'http://[::1]/',
-			'http://localhost:8080/'],
-		'scopes' => ['eap-metadata']
-	],
 
 	# Mobile application
 	# https://github.com/geteduroam/ionic-app/pull/47
-	[
-		'clientId' => 'app.geteduroam.ionic',
-		'redirectUris' => [
-			# Old client used http://localhost:8080 but we're not allowing that anymore
-			'http://[::1]/', 'http://127.0.0.1/',
-		],
-		'scopes' => ['eap-metadata']
-	],
-
 	[
 		'clientId' => 'app.eduroam.geteduroam',
 		'redirectUris' => ['app.eduroam.geteduroam:/'],


### PR DESCRIPTION
Some old clients haven't been used for a while now. There might still be some versions floating around, but it's probably about time to prevent these from working on new servers.