### PR TITLE
Prefix realm with SAML attr (ie. affiliation) with optional value map

### DIFF
--- a/etc/letswifi.conf.simplesaml.php
+++ b/etc/letswifi.conf.simplesaml.php
@@ -19,6 +19,13 @@
 					//	'eduPersonEntitlement' => 'geteduroam-user',
 					//	],
 					//'verifyAuthenticatingAuthority' => false,
+					//'userRealmPrefixAttribute' => 'eduPersonPrimaryAffiliation',
+					//'userRealmPrefixAttribute' => 'eduPersonAffiliation',
+					//'userRealmPrefixValueMap' => [
+					//        'employee' => 'mdw',
+					//        'staff' => null,
+					//        'student' => 'student',
+					//	],
 					'idpList' => [
 							'https://example.com'
 						],

--- a/src/letswifi/browserauth/simplesamlauth.php
+++ b/src/letswifi/browserauth/simplesamlauth.php
@@ -37,6 +37,12 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 	 */
 	private $userIdAttribute;
 
+	/** @var ?string */
+	private $userRealmPrefixAttribute;
+
+	/** @var array<string> */
+	private $userRealmPrefixValueMap;
+
 	/** @var ?array<string,array<string>> */
 	private $attributes = null;
 
@@ -54,11 +60,15 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 		}
 		$authSource = \array_key_exists( 'authSource', $params ) ? $params['authSource'] : 'default-sp';
 		$userIdAttribute = \array_key_exists( 'userIdAttribute', $params ) ? $params['userIdAttribute'] : null;
+		$userRealmPrefixAttribute = \array_key_exists( 'userRealmPrefixAttribute', $params ) ? $params['userRealmPrefixAttribute'] : null;
+		$userRealmPrefixValueMap = \array_key_exists( 'userRealmPrefixValueMap', $params ) ? $params['userRealmPrefixValueMap'] : [];
 		$samlIdp = \array_key_exists( 'samlIdp', $params ) ? $params['samlIdp'] : null;
 		$idpList = \array_key_exists( 'idpList', $params ) ? $params['idpList'] : [];
 		$verifyAuthenticatingAuthority = \array_key_exists( 'verifyAuthenticatingAuthority', $params ) ? $params['verifyAuthenticatingAuthority'] : true;
 		$authzAttributeValue = \array_key_exists( 'authzAttributeValue', $params ) ? $params['authzAttributeValue'] : [];
 		\assert( \is_string( $userIdAttribute ), 'userIdAttribute must be string' );
+		\assert( \is_string( $userRealmPrefixAttribute ), 'userRealmPrefixAttribute must be string' );
+		\assert( \is_array( $userRealmPrefixValueMap ), 'userRealmPrefixValueMap must be array' );
 		\assert( \is_string( $samlIdp ) || null === $samlIdp, 'samlIdp must be string if provided' );
 		\assert( \is_array( $idpList ), 'idpList must be array if provided' );
 		\assert( \is_array( $authzAttributeValue ), 'authzAttributeValue must be array if provided' );
@@ -69,6 +79,8 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 		$this->authzAttributeValue = $authzAttributeValue;
 		$this->as = new \SimpleSAML\Auth\Simple( $authSource );
 		$this->userIdAttribute = $userIdAttribute;
+		$this->userRealmPrefixAttribute = $userRealmPrefixAttribute;
+		$this->userRealmPrefixValueMap = $userRealmPrefixValueMap;
 	}
 
 	/**
@@ -113,6 +125,39 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 		}
 
 		return $this->getSingleAttributeValue( $this->userIdAttribute );
+	}
+
+	/**
+	 * @suppress PhanUndeclaredClassMethod We don't have a dependency on SimpleSAMLphp
+	 */
+	public function getUserRealmPrefix(): ?string
+	{
+		if ( null === $this->attributes ) {
+			$this->attributes = $this->as->getAttributes();
+			\assert( \is_array( $this->attributes ), 'SimpleSAMLphp always returns an array' );
+		}
+		if ( !\array_key_exists( $this->userRealmPrefixAttribute, $this->attributes ) ) {
+			return null;
+		}
+		\assert( \is_array( $this->attributes[$this->userRealmPrefixAttribute] ), 'SimpleSAMLphp always returns attributes as array' );
+
+		// if there is an userRealmPrefixValueMap, iterate over its values (order might be important) and return
+		if ( \count( $this->userRealmPrefixValueMap ) > 0 ) {
+			foreach ( $this->userRealmPrefixValueMap as $attribute => $value ) {
+				if ( \in_array( $attribute, $this->attributes[$this->userRealmPrefixAttribute] ) ) {
+					return $value;
+				}
+			}
+			return null;
+		}
+
+		// if there is no map, we hope there's just one attribute, ie. the eduPersonPrimaryAffiliation
+		if ( 1 === \count( $this->attributes[$this->userRealmPrefixAttribute] ) ) {
+			return \reset( $this->attributes[$this->userRealmPrefixAttribute] );
+		}
+
+		// we're unsure if there is no map, no prefix
+		return null;
 	}
 
 	/**

--- a/src/letswifi/browserauth/simplesamlauth.php
+++ b/src/letswifi/browserauth/simplesamlauth.php
@@ -144,10 +144,11 @@ class SimpleSAMLAuth implements BrowserAuthInterface
 		// if there is an userRealmPrefixValueMap, iterate over its values (order might be important) and return
 		if ( \count( $this->userRealmPrefixValueMap ) > 0 ) {
 			foreach ( $this->userRealmPrefixValueMap as $attribute => $value ) {
-				if ( \in_array( $attribute, $this->attributes[$this->userRealmPrefixAttribute] ) ) {
+				if ( \in_array( $attribute, $this->attributes[$this->userRealmPrefixAttribute], true ) ) {
 					return $value;
 				}
 			}
+
 			return null;
 		}
 

--- a/src/letswifi/letswifiapp.php
+++ b/src/letswifi/letswifiapp.php
@@ -81,8 +81,9 @@ class LetsWifiApp
 		if ( null === $sub ) {
 			throw new DomainException( 'No user subject available' );
 		}
+		$sub_values = \explode( ',', $sub );
 
-		return new User( $sub, $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'] );
+		return new User( $sub_values[0], $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'], $sub_values[1] );
 	}
 
 	public function getIP(): string

--- a/src/letswifi/letswifiapp.php
+++ b/src/letswifi/letswifiapp.php
@@ -83,7 +83,11 @@ class LetsWifiApp
 		}
 		$sub_values = \explode( ',', $sub );
 
-		return new User( $sub_values[0], $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'], $sub_values[1] );
+		if ( 2 === \count( $sub_values ) ) {
+			return new User( $sub_values[0], $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'], $sub_values[1] );
+		}
+
+		return new User( $sub, $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'] );
 	}
 
 	public function getIP(): string

--- a/src/letswifi/letswifiapp.php
+++ b/src/letswifi/letswifiapp.php
@@ -70,8 +70,9 @@ class LetsWifiApp
 	{
 		$auth = $this->getBrowserAuthenticator( $realm );
 		$userId = $auth->requireAuth();
+		$userRealmPrefix = $auth->getUserRealmPrefix();
 
-		return new User( $userId, null, $this->getIP(), $_SERVER['HTTP_USER_AGENT'] );
+		return new User( $userId, null, $this->getIP(), $_SERVER['HTTP_USER_AGENT'], $userRealmPrefix );
 	}
 
 	public function getUserFromGrant( Grant $grant ): User

--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -179,10 +179,10 @@ class Realm
 	{
 		$userKey = new PrivateKey( new OpenSSLConfig( OpenSSLConfig::KEY_RSA ) );
 		// empty, because both null === and empty string values should stay out of the realm
-		if ( empty ( $user->getUserAltRealm() ) ) {
+		if ( empty( $user->getUserAltRealm() ) ) {
 			$commonName = static::createRandomId() . '@' . \rawurlencode( $this->getName() );
 		} else {
-			$commonName = static::createRandomId() . '@' . \rawurlencode( \join ( ".", [ $user->getUserAltRealm(), $this->getName() ] ) );
+			$commonName = static::createRandomId() . '@' . \rawurlencode( \implode( '.', [$user->getUserAltRealm(), $this->getName()] ) );
 		}
 		$dn = new DN( ['CN' => $commonName] );
 		$csr = CSR::generate( $dn, $userKey );

--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -178,7 +178,12 @@ class Realm
 	protected function generateClientCertificate( User $user, DateTimeInterface $expiry ): PKCS12
 	{
 		$userKey = new PrivateKey( new OpenSSLConfig( OpenSSLConfig::KEY_RSA ) );
-		$commonName = static::createRandomId() . '@' . \rawurlencode( $this->getName() );
+		// empty, because both null === and empty string values should stay out of the realm
+		if ( empty ( $user->getUserAltRealm() ) ) {
+			$commonName = static::createRandomId() . '@' . \rawurlencode( $this->getName() );
+		} else {
+			$commonName = static::createRandomId() . '@' . \rawurlencode( \join ( ".", [ $user->getUserAltRealm(), $this->getName() ] ) );
+		}
 		$dn = new DN( ['CN' => $commonName] );
 		$csr = CSR::generate( $dn, $userKey );
 		$caCert = $this->getSigningCACertificate();

--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -180,9 +180,9 @@ class Realm
 		$userKey = new PrivateKey( new OpenSSLConfig( OpenSSLConfig::KEY_RSA ) );
 		// empty, because both null === and empty string values should stay out of the realm
 		if ( empty( $user->getUserAltRealm() ) ) {
-			$commonName = static::createRandomId() . '@' . \rawurlencode( $this->getName() );
+			$commonName = static::createCommonName( '@' . \rawurlencode( $this->getName() ) );
 		} else {
-			$commonName = static::createRandomId() . '@' . \rawurlencode( \implode( '.', [$user->getUserAltRealm(), $this->getName()] ) );
+			$commonName = static::createCommonName( '@' . \rawurlencode( \implode( '.', [$user->getUserAltRealm(), $this->getName()] ) ) );
 		}
 		$dn = new DN( ['CN' => $commonName] );
 		$csr = CSR::generate( $dn, $userKey );
@@ -197,8 +197,8 @@ class Realm
 		return new PKCS12( $userCert, $userKey, [$caCert] );
 	}
 
-	private static function createRandomId(): string
+	private static function createCommonName( string $realm ): string
 	{
-		return \strtolower( \strtr( \base64_encode( \random_bytes( 12 ) ), '/+9876', '012345' ) );
+		return \substr( \strtolower( \strtr( \base64_encode( \random_bytes( 12 ) ), '/+9876', '012345' ) ), 0, 64 - \strlen( $realm ) ) . $realm;
 	}
 }

--- a/src/letswifi/realm/user.php
+++ b/src/letswifi/realm/user.php
@@ -24,12 +24,16 @@ class User
 	/** @var ?string */
 	private $userAgent;
 
-	public function __construct( string $userId, ?string $clientId = null, ?string $ip = null, ?string $userAgent = null )
+	/** @var ?string */
+	private $userAltRealm;
+
+	public function __construct( string $userId, ?string $clientId = null, ?string $ip = null, ?string $userAgent = null, ?string $userAltRealm = null )
 	{
 		$this->userId = $userId;
 		$this->clientId = $clientId;
 		$this->ip = $ip;
 		$this->userAgent = $userAgent;
+		$this->userAltRealm = $userAltRealm;
 	}
 
 	public function getUserId(): string
@@ -50,5 +54,10 @@ class User
 	public function getUserAgent(): ?string
 	{
 		return $this->userAgent;
+	}
+
+	public function getUserAltRealm(): ?string
+	{
+		return $this->userAltRealm;
 	}
 }

--- a/www/oauth/authorize/index.php
+++ b/www/oauth/authorize/index.php
@@ -28,7 +28,11 @@ try {
 	$user = $app->getUserFromBrowserSession( $realm );
 
 	if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-		$oauth->handleAuthorizePostRequest( $user->getUserId(), POST_VALUE === $_POST[POST_FIELD] );
+		if ( null === $browserAuth->getUserRealmPrefix() ) {
+			$oauth->handleAuthorizePostRequest( $user->getUserId(), POST_VALUE === $_POST[POST_FIELD] );
+		} else {
+			$oauth->handleAuthorizePostRequest( $user->getUserId() . ',' . $browserAuth->getUserRealmPrefix(), POST_VALUE === $_POST[POST_FIELD] );
+		}
 
 		// handler should never return, this code should be unreachable
 		\header( 'Content-Type: text/plain' );

--- a/www/profiles/mac/index.php
+++ b/www/profiles/mac/index.php
@@ -20,7 +20,7 @@ $app->getUserFromBrowserSession( $realm );
 // on this page, which uses a more reliable POST.
 // If the meta_redirect would go through too late (after session expiry),
 // the page being redirected to will also contain an appropriate download button.
-session_start(['cookie_lifetime' => 60]);
+\session_start(['cookie_lifetime' => 60]);
 $_SESSION['mobileconfig-download-token'] = true;
 
 switch ( $_SERVER['REQUEST_METHOD'] ) {

--- a/www/profiles/new/index.php
+++ b/www/profiles/new/index.php
@@ -32,12 +32,12 @@ $user = $app->getUserFromBrowserSession( $realm );
 // assuming user came from /profiles/mac,
 // so that's the page that stays in the browser.
 if ( 'GET' === $_SERVER['REQUEST_METHOD'] && isset( $_GET['download'] ) ) {
-	session_start(['cookie_lifetime' => 1]);
-	if ( $_SESSION['mobileconfig-download-token'] ){
+	\session_start(['cookie_lifetime' => 1]);
+	if ( $_SESSION['mobileconfig-download-token'] ) {
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_POST['device'] = $_GET['device'];
 	}
-	session_destroy();
+	\session_destroy();
 }
 
 switch ( $_SERVER['REQUEST_METHOD'] ) {


### PR DESCRIPTION
Allow to prefix the users' realm based on a SAML attribute, like the eduPersonPrimaryAffiliation,
or in the case of eduPersonAffiliation (multi-value possible) allow an value map, to indicate what values are permitted and what they translate to.
We may need to check on/be aware of the maximum length of the CN.